### PR TITLE
Include causing exception when throwing Model Crashed

### DIFF
--- a/src/main/java/org/graphwalker/multipleModels/ModelHandler.java
+++ b/src/main/java/org/graphwalker/multipleModels/ModelHandler.java
@@ -71,7 +71,7 @@ public class ModelHandler {
     private ModelBasedTesting mbt;
     private Object modelAPI;
     private boolean executionRestarted = false;
-    private boolean crashed = false;
+    private Exception thrownException = null;
 
     public ModelRunnable(String name, ModelAPI modelAPI) {
       this.name = name;
@@ -85,7 +85,7 @@ public class ModelHandler {
         logger.debug("Will start executing the model: " + this.mbt.getGraph());
         mbt.executePath(modelAPI);
       } catch (Exception e) {
-        crashed = true;
+        thrownException = e;
         Util.logStackTraceToError(e);
       }
     }
@@ -99,7 +99,11 @@ public class ModelHandler {
     }
 
     public boolean isCrashed() {
-      return crashed;
+      return thrownException != null;
+    }
+    
+    public Exception crashException() {
+      return thrownException;
     }
 
     public boolean isExecutionRestarted() {
@@ -373,7 +377,7 @@ public class ModelHandler {
   private void check4Crash(ModelRunnable model) {
     if (model.isCrashed()) {
       logger.error("Model has crashed: " + model.getName());
-      throw new RuntimeException("Model has crashed");
+      throw new RuntimeException("Model has crashed", model.crashException());
     }
   }
 


### PR DESCRIPTION
This change includes the causing exception when throwing the Model Crashed exception.

The point is to make the Model Crashed exception more useful when caught by a unit testing framework.

Got the same results when running the unit tests before and after this change (two failures).
