### PR TITLE
Add Travis-ci build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GraphWalker
 
+[![Build Status](https://travis-ci.org/KristianKarl/GraphWalker.png)](https://travis-ci.org/KristianKarl/GraphWalker)
+
 GraphWalker is a Model-Based Testing tool. It parses models [finite-state machines] which are designed
 using the yEd, http://www.yworks.com/en/products_yed_about.html, and generates test sequences.
 The tool generates offline and more importanly, online test sequences from Finite State Machines and


### PR DESCRIPTION
Seeing as you are using Travis-ci for builds now, I thought you might like to have the status badge show up on the front page of the repository.
